### PR TITLE
Refactor to use better env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Before running each of the `.sh` scripts consider taking a look over the initial
 # Microsoft Azure
 
 - `./create-cluster-az.sh`: create an IPI provisioned OpenShift cluster on Azure public cloud
-- `./create-cluster-az.sh`: create an IPI provisioned OpenShift cluster on [Azure with short-term credentials with Active Directory (AD) Workload Identity](https://docs.openshift.com/container-platform/4.15/installing/installing_azure/installing-azure-customizations.html#installing-azure-with-short-term-creds_installing-azure-customizations)
+- `./create-cluster-az-sts.sh`: create an IPI provisioned OpenShift cluster on [Azure with short-term credentials with Active Directory (AD) Workload Identity](https://docs.openshift.com/container-platform/4.15/installing/installing_azure/installing-azure-customizations.html#installing-azure-with-short-term-creds_installing-azure-customizations)
 
 # Cleanup
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,15 @@ This repo contains bash scripts to help automate creation of OpenShift clusters 
 
 **Pre-requisites**:
 - `oc` cli installed and available in `$PATH`
-- `podman`
-- `ccoctl` binary available in current directory (this is only needed if you plan to use `*-sts.sh` scripts)
 - cloud provider cli setup with necessary authentication for eg. AWS credentials available to be inferred from current environment or GCP credentials gcloud default auth setup
 - necessary cloud provider quota required for spinning up cluster resources for OpenShift
 - `~/.docker/config.json` file on your system to contain the necessary pull secrets required for cluster creation
+    - or any other location would work for the pull secrets file, however you would need to set `PULL_SECRET_PATH` environment variable explicitly
 - either `~/.ssh/google_compute_engine.pub` (for GCP) or `~/.ssh/id_rsa.pub` (for AWS, Azure) to be present on your system
 
-You can download all these binaries either from: https://console.redhat.com/openshift/downloads or from our CI: https://amd64.ocp.releases.ci.openshift.org/
+You can download all these binaries either from: https://console.redhat.com/openshift/downloads or from our OpenShift CI: https://amd64.ocp.releases.ci.openshift.org/
 
-Before running each of the `.sh` scripts consider taking a look over the initial block of code in the script which contains values for certain environment variables. They have been filled with default values (yet wont work out of the box), but you would need to change them on the basis of your cloud provider resource names eg. cloud project, cloud region, base domain, etc.
+Before running each of the `.sh` scripts consider taking a look over the initial block of code in each of the script preceeding `# --------------------`, should contains description for each environment variable necessary for the cluster creation to run. They have been filled with default values (yet wont work out of the box), instead you need to set those variables in your environment (i.e. either before calling the script or by creating a wrapper script which contains exact values of the required variables) especially, the cloud provider resource ids eg. cloud project, cloud region, base domain, etc.
 
 # Amazon Web Services (AWS)
 

--- a/create-cluster-aws.sh
+++ b/create-cluster-aws.sh
@@ -1,25 +1,31 @@
 #!/usr/bin/bash
 
 # override release image with custom release and create the cluster from supplied install-config
-export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/openshift-release-dev/ocp-release:4.16.0-ec.1-x86_64
+export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE:-"quay.io/openshift-release-dev/ocp-release:4.15.3-x86_64"}
+AWS_REGION=${AWS_REGION:-"ap-south-1"}
+# base domain for cluster creation, must be route53 dns zone
+BASE_DOMAIN=${BASE_DOMAIN:-"openshift.codecrafts.cf"}
+# path to file containing pull secrets
+PULL_SECRET_PATH=${PULL_SECRET_PATH:-"$HOME/.docker/config.json"}
+
+# --------------------
 
 # generate a cluster name with username, date and 8 random hex
 CLUSTER_NAME=$(whoami)-$(date +"%Y%m%d")-$(echo $RANDOM | md5sum | head -c 8)
 export CLUSTER_NAME
 
-AWS_REGION=ap-south-1
-
 # get pull secrets
-PULL_SECRET_PATH=~/.docker/config.json
-PULL_SECRET=$(python3 json-minify.py $PULL_SECRET_PATH)
+PULL_SECRET=$(python3 json-minify.py "$PULL_SECRET_PATH")
 
 # create an install-config in a directory
 CLUSTER_DIR="clusters/$CLUSTER_NAME"
 mkdir -p "$CLUSTER_DIR"
 
+oc adm release extract --command='openshift-install' ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}
+
 cat << EOF > "$CLUSTER_DIR"/install-config.yaml
 apiVersion: v1
-baseDomain: devcluster.openshift.com
+baseDomain: ${BASE_DOMAIN}
 # featureSet: "TechPreviewNoUpgrade"
 compute:
 - architecture: amd64
@@ -53,14 +59,9 @@ sshKey: |
   $(cat ~/.ssh/id_rsa.pub)
 EOF
 
-# openshift-install
-installer_image="$(podman run --rm "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}" image installer)"
-tmp_dir=$(mktemp -d)
-podman run --entrypoint sh -u root --rm -v "${tmp_dir}:/workdir:Z" "${installer_image}" -c "cp -rvf /bin/openshift-install /workdir"
-
-"${tmp_dir}/openshift-install" create manifests --dir "${CLUSTER_DIR}" --log-level debug 2>&1 | tee "$CLUSTER_NAME".log
+./openshift-install create manifests --dir "${CLUSTER_DIR}" --log-level debug 2>&1 | tee "$CLUSTER_NAME".log
 read -r -n 1 -p "Manifests have been created, press any key to continue to cluster creation step... "
-"${tmp_dir}/openshift-install" create cluster --dir "${CLUSTER_DIR}" --log-level debug 2>&1 | tee -a "$CLUSTER_NAME".log
+./openshift-install create cluster --dir "${CLUSTER_DIR}" --log-level debug 2>&1 | tee -a "$CLUSTER_NAME".log
 
 # after cluster creation succeeds copy kubeconfig to ~/.kube/config
 cp -f "$CLUSTER_DIR"/auth/kubeconfig ~/.kube/config

--- a/create-cluster-az.sh
+++ b/create-cluster-az.sh
@@ -10,9 +10,9 @@ AZ_DNS_RESOURCE_GROUP=${AZ_DNS_RESOURCE_GROUP:-"dns-rg"}
 # path to file containing pull secrets
 PULL_SECRET_PATH=${PULL_SECRET_PATH:-"$HOME/.docker/config.json"}
 # azure subscription id, required!
-az_subscription_id=${az_subscription_id:-"invalid-subscription-id"}
+AZ_SUBSCRIPTION_ID=${AZ_SUBSCRIPTION_ID:-"invalid-subscription-id"}
 # whether to az login, default is true
-az_login=${az_login:-"1"}
+AZ_LOGIN=${AZ_LOGIN:-"1"}
 
 # --------------------
 
@@ -20,9 +20,33 @@ az_login=${az_login:-"1"}
 # run this every few days or so,
 # the following az commands are not required if you already 
 # have a valid ~/.azure/osServicePrincipal.json present
-if [ "${az_login}" -eq "1" ]; then
+if [ "${AZ_LOGIN}" -eq "1" ]; then
+  az_client_cred_tmp_dir="$(mktemp -d)"
+  
   az login
-  az ad sp create-for-rbac --role Owner --name "$(whoami)"-installer --scopes "/subscriptions/${az_subscription_id}"
+  az ad sp create-for-rbac --role Owner --name "$(whoami)"-installer --scopes "/subscriptions/${AZ_SUBSCRIPTION_ID}" > "$az_client_cred_tmp_dir"/az_credentials.json
+
+  # IMPORTANT: Please ensure ~/.azure/osServicePrincipal.json contains a valid token!
+  # Else, azure cannot authenticate. To avoid problems, rm ~/.azure/osServicePrincipal.json and 
+  # fill subscription id, tenant id, client app id and client secret manually from output of above command.
+
+  python3 - << EOF
+import json, os
+with open('${az_client_cred_tmp_dir}/az_credentials.json', 'r') as src_f:
+  az_creds = json.load(src_f)
+
+os_creds = {
+  "subscriptionId": "${AZ_SUBSCRIPTION_ID}",
+  "clientId": f"{az_creds['appId']}",
+  "clientSecret": f"{az_creds['password']}",
+  "tenantId": f"{az_creds['tenant']}"
+}
+
+os.makedirs("${HOME}/.azure", exist_ok=True)
+with open('${HOME}/.azure/osServicePrincipal.json', 'w') as dst_f:
+  json.dump(os_creds, dst_f)
+EOF
+
 fi
 
 # generate a cluster name with username, date and 8 random hex

--- a/create-cluster-az.sh
+++ b/create-cluster-az.sh
@@ -2,25 +2,44 @@
 set -euo pipefail
 
 # override release image with custom release and create the cluster from supplied install-config
-export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/openshift-release-dev/ocp-release:4.13.0-x86_64
-
-AZ_REGION="centralindia"
-
+export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE:-"quay.io/openshift-release-dev/ocp-release:4.15.3-x86_64"}
+AZ_REGION=${AZ_REGION:-"centralus"}
 # base domain for cluster creation, must be Azure DNS zone
-BASE_DOMAIN="catchall.azure.devcluster.openshift.com"
-BASE_DOMAIN_RESOURCE_GROUP="os4-common"
+BASE_DOMAIN=${BASE_DOMAIN:-"openshift.codecrafts.cf"}
+AZ_DNS_RESOURCE_GROUP=${AZ_DNS_RESOURCE_GROUP:-"dns-rg"}
+# path to file containing pull secrets
+PULL_SECRET_PATH=${PULL_SECRET_PATH:-"$HOME/.docker/config.json"}
+# azure subscription id, required!
+az_subscription_id=${az_subscription_id:-"invalid-subscription-id"}
+# whether to az login, default is true
+az_login=${az_login:-"1"}
 
-# get pull secrets
-PULL_SECRET_PATH=~/.docker/config.json
-PULL_SECRET=$(python3 json-minify.py $PULL_SECRET_PATH)
+# --------------------
+
+# azure credentials pre-init
+# run this every few days or so,
+# the following az commands are not required if you already 
+# have a valid ~/.azure/osServicePrincipal.json present
+if [ "${az_login}" -eq "1" ]; then
+  az login
+  az ad sp create-for-rbac --role Owner --name "$(whoami)"-installer --scopes "/subscriptions/${az_subscription_id}"
+fi
 
 # generate a cluster name with username, date and 8 random hex
 CLUSTER_NAME=$(whoami)-$(date +"%Y%m%d")-$(echo $RANDOM | md5sum | head -c 8)
 export CLUSTER_NAME
 
 # create an install-config in a directory
-mkdir "$CLUSTER_NAME"
-cat << EOF > "$CLUSTER_NAME"/install-config.yaml
+CLUSTER_DIR="clusters/$CLUSTER_NAME"
+mkdir -p "$CLUSTER_DIR"
+
+# get pull secrets
+PULL_SECRET=$(python3 json-minify.py "$PULL_SECRET_PATH")
+
+oc adm release extract --command='openshift-install' ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}
+
+# create an install-config in a directory
+cat << EOF > "$CLUSTER_DIR"/install-config.yaml
 additionalTrustBundlePolicy: Proxyonly
 apiVersion: v1
 baseDomain: ${BASE_DOMAIN}
@@ -29,7 +48,7 @@ compute:
   hyperthreading: Enabled
   name: worker
   platform: {}
-  replicas: 3
+  replicas: 1
 controlPlane:
   architecture: amd64
   hyperthreading: Enabled
@@ -50,7 +69,7 @@ networking:
   - 172.30.0.0/16
 platform:
   azure:
-    baseDomainResourceGroupName: ${BASE_DOMAIN_RESOURCE_GROUP}
+    baseDomainResourceGroupName: ${AZ_DNS_RESOURCE_GROUP}
     cloudName: AzurePublicCloud
     outboundType: Loadbalancer
     region: ${AZ_REGION}
@@ -61,9 +80,9 @@ sshKey: |
   $(cat ~/.ssh/id_rsa.pub)
 EOF
 
-./openshift-install create manifests --dir "$CLUSTER_NAME" --log-level debug 2>&1 | tee "$CLUSTER_NAME".log
+./openshift-install create manifests --dir "${CLUSTER_DIR}" --log-level debug 2>&1 | tee "$CLUSTER_NAME".log
 read -r -n 1 -p "Manifests have been created, press any key to continue to cluster creation step... "
-./openshift-install create cluster --dir "$CLUSTER_NAME" --log-level debug 2>&1 | tee -a "$CLUSTER_NAME".log
+./openshift-install create cluster --dir "${CLUSTER_DIR}" --log-level debug 2>&1 | tee -a "$CLUSTER_NAME".log
 
 # after cluster creation succeeds copy kubeconfig to ~/.kube/config
-cp -f "$CLUSTER_NAME"/auth/kubeconfig ~/.kube/config
+cp -f "${CLUSTER_DIR}"/auth/kubeconfig ~/.kube/config

--- a/destroy-clusters.sh
+++ b/destroy-clusters.sh
@@ -5,6 +5,8 @@ NUM_CLUSTERS_TO_KEEP=${1:-"0"}
 LOOKUP_DIR=${LOOKUP_DIR:-"./clusters"}
 CLUSTER_PREFIX=${CLUSTER_PREFIX:-"$(whoami)"}
 
+# --------------------
+
 echo "Removing all clusters except for last" "$NUM_CLUSTERS_TO_KEEP"
 echo "Looking up cluster directories from" "$LOOKUP_DIR"
 

--- a/destroy-clusters.sh
+++ b/destroy-clusters.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 NUM_CLUSTERS_TO_KEEP=${1:-"0"}
 LOOKUP_DIR=${LOOKUP_DIR:-"./clusters"}
-CLUSTER_PREFIX=${CLUSTER_PREFIX:-"$(whoami)-"}
+CLUSTER_PREFIX=${CLUSTER_PREFIX:-"$(whoami)"}
 
 echo "Removing all clusters except for last" "$NUM_CLUSTERS_TO_KEEP"
 echo "Looking up cluster directories from" "$LOOKUP_DIR"


### PR DESCRIPTION
This change refactors/revamps the scripts to use better env variables injections. Essentially, this allows script usage to be wrapped in another caller script where sensitive env var values can be set.


Manual test runs passed for:
- [x] gcp
- [x] gcp-sts
- [x] aws
- [x] aws-sts
- [x] az
- [x] az-sts